### PR TITLE
Mount aditional volumes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,7 +27,7 @@
 	"runArgs": [
 		"--ipc=host",
 		"--volume=/dev:/dev",
-		"--volume=/run:/run2",
+		"--volume=/run/udev:/run/udev",
 		"--privileged"
 	]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,6 +26,8 @@
 	},
 	"runArgs": [
 		"--ipc=host",
+		"--volume=/dev:/dev",
+		"--volume=/run:/run2",
 		"--privileged"
 	]
 }

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -24,3 +24,5 @@ go install github.com/pilebones/go-udev@latest
 
 make binaries GO_BUILD_FLAGS="-mod=vendor"
 sudo -E PATH=$PATH make install
+sudo mkdir -p /run/udev
+sudo mount -o bind /run2/udev /run/udev

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -24,5 +24,3 @@ go install github.com/pilebones/go-udev@latest
 
 make binaries GO_BUILD_FLAGS="-mod=vendor"
 sudo -E PATH=$PATH make install
-sudo mkdir -p /run/udev
-sudo mount -o bind /run2/udev /run/udev


### PR DESCRIPTION
This will mount the host's ```/dev``` and ```/run/udev``` inside the container. Mounting the host ```/dev``` will give us access to the newly added devices and mounting ```/run/udev``` gives us access to ```/run/udev/control``` used by ```dmsetup``` to sync with udev.